### PR TITLE
Update copyright messages

### DIFF
--- a/hostlists/__init__.py
+++ b/hostlists/__init__.py
@@ -5,14 +5,12 @@ _metadata_file = os.path.join(
     os.path.dirname(__file__),
     'package_metadata.json'
 )
-if os.path.exists(_metadata_file):
+
+if os.path.exists(_metadata_file):  # pragma: no cover
     with open(_metadata_file) as fh:
         _package_metadata = json.load(fh)
         __version__ = _package_metadata['version']
 else:
     __version__ = '0.0.0'
 
-try:
-    from hostlists.hostlists import *
-except ImportError:
-    from hostlists import *
+from .hostlists import *

--- a/hostlists/hostlists.py
+++ b/hostlists/hostlists.py
@@ -53,7 +53,17 @@ if 'basestring' not in dir(__builtins__):
     basestring = str
 
 
+class HostListsError(Exception):
+    pass
+
+
 def cmp_compat(a, b):
+    """
+    Simple comparison function
+    :param a:
+    :param b:
+    :return:
+    """
     return (a > b) - (a < b)
 
 # noinspection PyBroadException
@@ -121,15 +131,21 @@ def installed_plugins():
     return plugins
 
 def get_setting(key):
+    """
+    Get setting values from CONF_FILE
+    :param key:
+    :return:
+    """
     try:
-        settings = json.load(open(CONF_FILE, 'r'))
+        with open(CONF_FILE) as cf:
+            settings = json.load(cf)
     except IOError:
         # Couldn't open the settings file
         #print 'No such conf file'
         return None
     if key in settings.keys():
         return settings[key]
-    return None
+    return None    # pragma: no cover
 
 
 def expand(range_list, onepass=False):
@@ -139,7 +155,7 @@ def expand(range_list, onepass=False):
     ['foo09', 'foo08', 'foo07', 'foo02', 'foo01', 'foo03', 'foo10']
     >>> 
     """
-    if isinstance(range_list, basestring):
+    if isinstance(range_list, basestring):  # pragma: no cover
         range_list = [h.strip() for h in range_list.split(',')]
     new_list = []
     set1 = None
@@ -154,7 +170,7 @@ def expand(range_list, onepass=False):
             set1 = new_list.pop()
             operation = item
         else:
-            expanded_item = expand_item(item, onepass = onepass)
+            expanded_item = expand_item(item, onepass=onepass)
             new_list.append(expanded_item)
     new_list2 = []
     for item in new_list:
@@ -207,10 +223,10 @@ def expand_item(range_list, onepass=False):
                 found_plugin = True
             else:
                 # This should probably just be an exception
-                print(
-                    'plugin', plugin,
-                    'not found, valid plugins are:', ','.join(plugins.keys()),
-                    file=sys.stderr
+                raise HostListsError(
+                    'plugin %s not found, value plugins are: %s' % (
+                        plugin, ','.join(plugins.keys())
+                    )
                 )
         else:
             # Default to running through the range plugin
@@ -229,7 +245,6 @@ def expand_item(range_list, onepass=False):
 
 
 def multikeysort(items, columns):
-
     comparers = [
         ((operator.itemgetter(col[1:].strip()), -1) if col.startswith('-') else (operator.itemgetter(col.strip()), 1)) for col in columns
     ]
@@ -328,7 +343,10 @@ def compress_domain(hostnames):
             else:
                 result.append(
                     '%s[%s-%s]%s' % (
-                        item[0]['prefix'], item[0]['number'], item[-1]['number'], item[0]['suffix']
+                        item[0]['prefix'],
+                        item[0]['number'],
+                        item[-1]['number'],
+                        item[0]['suffix']
                     )
                 )
     return result

--- a/hostlists/plugins/__init__.py
+++ b/hostlists/plugins/__init__.py
@@ -1,1 +1,1 @@
-__author__ = 'dhubbard'
+

--- a/hostlists/plugins/dns.py
+++ b/hostlists/plugins/dns.py
@@ -1,21 +1,20 @@
 #!/usr/bin/env python
+from __future__ import absolute_import
 """ hostlists plugin to get hosts from dns """
 
-#noinspection PyStatementEffect
-"""
- Copyright (c) 2012-2014 Yahoo! Inc. All rights reserved.
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
+# Copyright (c) 2012-2015 Yahoo! Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License. See accompanying LICENSE file.
 
- http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,   
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License. See accompanying LICENSE file.
-"""
 
 import dns.resolver
 import dns.reversename
@@ -53,4 +52,3 @@ def expand(value):
     if len(tmplist) < len(addresses):
         return addresses
     return tmplist
-  

--- a/hostlists/plugins/dnsip.py
+++ b/hostlists/plugins/dnsip.py
@@ -1,20 +1,21 @@
 #!/usr/bin/env python
+from __future__ import absolute_import
 """ hostlists plugin to get hosts from dns """
 
-__license__ = """
- Copyright (c) 2012-2014 Yahoo! Inc. All rights reserved.
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
+ # Copyright (c) 2012-2015 Yahoo! Inc. All rights reserved.
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License. See accompanying LICENSE file.
 
- http://www.apache.org/licenses/LICENSE-2.0
 
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,   
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License. See accompanying LICENSE file.
-"""
 import dns.resolver
 
 
@@ -31,4 +32,3 @@ def expand(value):
     for rdata in answers:
         tmplist.append(rdata.address)
     return tmplist
-  

--- a/hostlists/plugins/range.py
+++ b/hostlists/plugins/range.py
@@ -60,7 +60,7 @@ def block_to_list(block):
                 val = ''
             if letter == ',':
                 if val1 is not None:
-                    result.append(val1.zfill(val1_len))
+                    result.append(val1.zfill(val1_len))  # pragma: no cover
             else:
                 in_range = True
         else:
@@ -88,4 +88,4 @@ def expand_item(item):
     if len(result):
         return result
     else:
-        return [item]
+        return [item]  # pragma: no cover

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -25,8 +25,6 @@ class TestHostlistsExpand(unittest.TestCase):
     """
     hostmap unit tests
     """
-    def set_up(self):
-        pass
 
     class base_test_expand_string_input(unittest.TestCase):
         range_list = 'localhost'

--- a/tests/test_hostlists.py
+++ b/tests/test_hostlists.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+#Copyright (c) 2012-2015 Yahoo! Inc. All rights reserved.
+#Licensed under the Apache License, Version 2.0 (the "License");
+#you may not use this file except in compliance with the License.
+#You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License. See accompanying LICENSE file.
+"""
+Unit tests of sshmap
+"""
+import hostlists
+import json
+import os
+import tempfile
+import types
+import unittest
+
+
+class TestHostlists(unittest.TestCase):
+    """
+    hostlists.py unit tests
+    """
+    def test_cmp_compat(self):
+        self.assertEqual(hostlists.cmp_compat(1, 2), -1)
+        self.assertEqual(hostlists.cmp_compat(2, 1), 1)
+
+    def test_get_plugins(self):
+        plugins = hostlists.get_plugins()
+        self.assertIn('file', plugins.keys())
+        self.assertIsInstance(plugins['file'], types.ModuleType)
+
+    def test_get_setting_without_config_file(self):
+        if os.path.exists('test_get_setting.conf'):
+            os.remove('test_get_setting.conf')
+        hostlists.hostlists.CONF_FILE = os.path.abspath('test_get_setting.conf')
+        result = hostlists.get_setting('key')
+        self.assertIsNone(result)
+
+    def test_get_setting_with_config_file(self):
+        expected_dict = {
+            'key': 'value'
+        }
+        with open('test_get_setting.conf', 'w') as tf:
+            json.dump(expected_dict, tf)
+        hostlists.hostlists.CONF_FILE = os.path.abspath('test_get_setting.conf')
+        result = hostlists.get_setting('key')
+        os.remove('test_get_setting.conf')
+        self.assertEqual(result, 'value')
+
+    def test_expand(self):
+        """
+        Expand a list of lists and set operators into a final host lists
+        >>> hostlists.expand(['foo[01-10]','-','foo[04-06]'])
+        ['foo09', 'foo08', 'foo07', 'foo02', 'foo01', 'foo03', 'foo10']
+        >>>
+        """
+        result = hostlists.expand(['foo[01-10]','-','foo[04-06]'])
+        expected_result = [
+            'foo09', 'foo08', 'foo07', 'foo02', 'foo01', 'foo03', 'foo10']
+        result.sort()
+        expected_result.sort()
+        self.assertLessEqual(result, expected_result)
+
+    def test_expand_invalid_plugin(self):
+        with self.assertRaises(hostlists.HostListsError) as context:
+            result = hostlists.expand(['boozle:bar'])
+
+    def test_expand_file(self):
+        with open('test_expand_file.hostlist', 'w') as fh:
+            fh.write('foo[1-2]\n')
+        result = hostlists.expand(['file:test_expand_file.hostlist'])
+        expected_result = ['foo1', 'foo2']
+        os.remove('test_expand_file.hostlist')
+        result.sort()
+        self.assertListEqual(result, expected_result)
+
+    def test_compress(self):
+        result = hostlists.compress(['foo1', 'foo3', 'foo4'])
+        expected_result = ['foo1', 'foo[3-4]']
+        self.assertListEqual(result, expected_result)
+
+    def test_range_split(self):
+        result = hostlists.range_split('foo1, foo[3-9]')
+        expected_result = ['foo1', ' foo[3-9]']
+        self.assertListEqual(result, expected_result)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_plugin_load.py
+++ b/tests/test_plugin_load.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+# Copyright (c) 2012-2015 Yahoo! Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License. See accompanying LICENSE file.
+"""
+Unit tests of sshmap
+"""
+import hostlists
+import unittest
+
+
+class TestHostPluginLoad(unittest.TestCase):
+    """
+    hostmap unit tests
+    """
+    def setUp(self):
+        self.hostlists_plugins = hostlists.installed_plugins()
+
+    def testPluginDnsLoad(self):
+        import hostlists.plugins.dns
+        self.assertIn('dns', hostlists.plugins.dns.name())
+        self.assertIn('dns', self.hostlists_plugins)
+
+    def testPluginDnsIPLoad(self):
+        import hostlists.plugins.dnsip
+        self.assertIn('dnsip', hostlists.plugins.dnsip.name())
+        self.assertIn('dnsip', self.hostlists_plugins)
+
+    def testPluginFileLoad(self):
+        import hostlists.plugins.file
+        self.assertIn('file', hostlists.plugins.file.name())
+        self.assertIn('file', self.hostlists_plugins)
+
+    def testPluginHaproxyLoad(self):
+        import hostlists.plugins.haproxy
+        self.assertIn('haproxy', hostlists.plugins.haproxy.name())
+        self.assertIn('haproxy', self.hostlists_plugins)
+
+    def testPluginRangeLoad(self):
+        import hostlists.plugins.range
+        self.assertIn('range', hostlists.plugins.range.name())
+        self.assertIn('range', self.hostlists_plugins)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
PEP8 cleanups

Fix import issue in the dns/dnsip plugins when run on python 2.7

Switch __init__.py to use a correct relative import

Use a context manager in get_setting to prevent unclosed files

Add an exception for invalid plugin use.

Add more unit tests