### PR TITLE
Update setup.cfg

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -25,6 +25,8 @@ jobs:
 
     validate_test:
         template: python/validate_unittest
+        environment:
+            TOX_ENVLIST: py39,py310,py311,py312
         requires: [~commit, ~pr]
 
     validate_documentation:

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -11,10 +11,6 @@ jobs:
         template: python/validate_codestyle
         requires: [~commit, ~pr]
 
-    validate_dependencies:
-        template: python/validate_dependencies
-        requires: [~commit, ~pr]
-
     validate_lint:
         template: python/validate_lint
         requires: [~commit, ~pr]
@@ -37,7 +33,7 @@ jobs:
 
     generate_version:
         template: python/generate_version
-        requires: [validate_test, validate_lint, validate_codestyle, validate_dependencies, validate_security]
+        requires: [validate_test, validate_lint, validate_codestyle, validate_security]
 
     publish_test_pypi:
         template: python/package_python

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -22,7 +22,7 @@ jobs:
     validate_test:
         template: python/validate_unittest
         environment:
-            TOX_ENVLIST: py39,py310,py311,py312
+            TOX_ENVLIST: py39,py310,py311
         requires: [~commit, ~pr]
 
     validate_documentation:

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ packages =
     hostlists
     hostlists.plugins
     hostlists_plugins_default
-python_requires = >="3.9"
+python_requires = >=3.9
 zip_safe = True
 
 [options.entry_points]

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,10 +14,10 @@ classifier =
     Operating System :: MacOS :: MacOS X
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.5
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: Implementation :: CPython
     Topic :: System :: Systems Administration
     Topic :: Utilities
@@ -36,14 +36,13 @@ version = 0.10.0
 
 [options]
 install_requires =
-    dnspython;python_version<"3.0"
-    dnspython3;python_version>="3.0"
+    dnspython
     requests
 packages =
     hostlists
     hostlists.plugins
     hostlists_plugins_default
-python_requires = >="3.5"
+python_requires = >="3.9"
 zip_safe = True
 
 [options.entry_points]

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ package_name = hostlists
 
 [tox]
 skip_missing_interpreters=True
-envlist = py39,py310,py311,py312
+envlist = py39,py310,py311
 
 [testenv]
 changedir = {toxinidir}

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ package_name = hostlists
 
 [tox]
 skip_missing_interpreters=True
-envlist = py36,py37,py38
+envlist = py39,py310,py311,py312
 
 [testenv]
 changedir = {toxinidir}
@@ -14,7 +14,9 @@ commands =
 deps =
 	pytest
 	pytest-cov
-passenv = SSH_AUTH_SOCK BUILD_NUMBER
+passenv = 
+    SSH_AUTH_SOCK
+    BUILD_NUMBER
 extras =
 	test
 
@@ -52,7 +54,6 @@ deps =
 	isort<=4.2.15
 	six
 	pylint
-basepython = python3.6
 commands = {envpython} {envbindir}/pylint --output-format=parseable {[config]package_dir}
 passenv = SSH_AUTH_SOCK BUILD_NUMBER
 extras =
@@ -64,6 +65,8 @@ deps =
 	lxml
 commands =
 	mypy --ignore-missing-imports --txt-report artifacts/mypy src/screwdrivercd
-passenv = SSH_AUTH_SOCK BUILD_NUMBER
+passenv = 
+	SSH_AUTH_SOCK
+ 	BUILD_NUMBER
 extras =
 	mypy


### PR DESCRIPTION
Update the dnspython dependencies, dnspython3 is no longer maintained because the python3 support has been merged into the original dnspython package.  So we remove the dnspython3 dependency.

Make changes to make the PR jobs work.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
